### PR TITLE
Fix Admin Menu

### DIFF
--- a/inc/docsify.php
+++ b/inc/docsify.php
@@ -156,6 +156,15 @@ class WPDocsify {
 		self::$prism = $languages;
 	}
 
+	public static function abs_path_to_url( $path = '' ) {
+    $url = str_replace(
+        wp_normalize_path( untrailingslashit( ABSPATH ) ),
+        site_url(),
+        wp_normalize_path( $path )
+    );
+    return esc_url_raw( $url );
+}
+
 	/* Register default Admin Documentation Page */
 	public static function adminRegister($arr = array()){
 		if(empty($arr)) return;
@@ -163,7 +172,13 @@ class WPDocsify {
 		if(!isset($arr['location'])) $arr['location'] = self::$baseDir;
 		else {
 			/* determine Base Directory */
-			$dir_absolute = str_replace(self::$site_url, trailingslashit(get_home_path()), $arr['location']);
+			$dir_absolute = str_replace(self::$site_url, trailingslashit(ABSPATH), $arr['location']);
+
+			/* fixing the mess */
+			$dir_absolute = $arr['location'];
+			self::$site_url = get_home_url();
+			$arr['location'] = self::abs_path_to_url($arr['location']);
+			
 			/* if stylesheet directory documentation does not exist revert to $baseDir */
 			if(!is_dir($dir_absolute)) $arr['location'] = self::$baseDir;
 		}
@@ -172,6 +187,7 @@ class WPDocsify {
 		/* set admin page */
 		self::$adminpage = $arr;
 	}
+
 
 	/* Register new Sub Documention Pages */
 	public static function register($arr) {

--- a/inc/docsify.php
+++ b/inc/docsify.php
@@ -277,7 +277,7 @@ class WPDocsify {
 		add_menu_page(
 			__(self::$adminpage['domain'], 'textdomain'),
 			self::$adminpage['name'],
-			'manage_options',
+			'read',
 			self::$adminpage['slug'],
 			function() {
 				self::Handler(self::$adminpage['location'],self::$adminpage['config']);
@@ -299,7 +299,7 @@ class WPDocsify {
 				self::$adminpage['slug'],
 				$sub_page['title'],
 				isset($sub_page['label']) ? $sub_page['label'] : $sub_page['title'],
-				'manage_options',
+				'read',
 				$sub_page['slug'],
 				function() use($sub_page) {
 					self::Handler($sub_page['location'],$sub_page['config']);


### PR DESCRIPTION
Since we already have separate restrictions implemented, the admin menu should have no restrictions and should appear to all users.

Currently, it does not appear to anyone except administrators, which defeats the purpose.